### PR TITLE
Add doc linking to new PEP-9999 location in old one

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -1,0 +1,2 @@
+Due to a restructuring of the upstream PEP repo, PEP-9999 has been moved to
+`peps/pep-9999.rst <peps/pep-9999.rst>`_.


### PR DESCRIPTION
Because the summary at the top of https://github.com/python/typing/issues/548 still links to the old PEP and I don't want to bother the Python typing devs with updating it every time something like this changes, maybe there could be a file redirecting to the new PEP-9999 location at the old one.

This PR adds such a file.

I tried it with a symlink first, but GitHub just displays them as empty files, so that isn't useful. This should work as a compromise.